### PR TITLE
removed typed return of function

### DIFF
--- a/Service/DoctorDataRequest.php
+++ b/Service/DoctorDataRequest.php
@@ -7,7 +7,7 @@ use Cfm\SoapSymfonyBundle\Request\CfmSoapClient;
 
 class DoctorDataRequest
 {
-    public static function Consultar(DoctorData $doctorData, String $key): Array
+    public static function Consultar(DoctorData $doctorData, String $key)
     {
         $cfmSoap = new CfmSoapClient();
         $cfmSoap->createClient();


### PR DESCRIPTION
When no data is found about the requested doctor, an empty string is returned from CFM, istead of an array.